### PR TITLE
Fix ConcurrentModificationException in onWorldViewUnloaded

### DIFF
--- a/src/main/java/com/datbear/BearycudaTrialsPlugin.java
+++ b/src/main/java/com/datbear/BearycudaTrialsPlugin.java
@@ -428,17 +428,8 @@ public class BearycudaTrialsPlugin extends Plugin {
         }
         toadFlagsById.entrySet().removeIf(entry -> entry.getValue().isEmpty());
 
-        for (var boat : trialBoatsById.values()) {
-            if (event.getWorldView() == boat.getWorldView()) {
-                trialBoatsById.remove(boat.getId());
-            }
-        }
-
-        for (var crate : trialCratesById.values()) {
-            if (event.getWorldView() == crate.getWorldView()) {
-                trialCratesById.remove(crate.getId());
-            }
-        }
+        trialBoatsById.entrySet().removeIf(entry -> event.getWorldView() == entry.getValue().getWorldView());
+        trialCratesById.entrySet().removeIf(entry -> event.getWorldView() == entry.getValue().getWorldView());
 
         for (var boostList : trialBoostsById.values()) {
             boostList.removeIf(obj -> event.getWorldView() == obj.getWorldView());


### PR DESCRIPTION
**Description:**

When using the plugin I noticed the overlay for the path and boosts
was not properly applying. Pulled the plugin and ran it locally and saw it was failing due to NPE.

Stacktrace example:
```
  java.util.ConcurrentModificationException: null
      at
  java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1597)
      at
  java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1625)
      at com.datbear.BearycudaTrialsPlugin.onWorldViewUnloaded(Bearycud
  aTrialsPlugin.java:437)
      ...
  java.lang.NullPointerException: Cannot read field "uc" because
  "this.vs" is null
      at jn.getModel(jn.java:65453)
      at net.runelite.client.ui.overlay.outline.ModelOutlineRenderer.dr
  awOutline(ModelOutlineRenderer.java:1001)
      at com.datbear.BearycudaTrialsOverlay.highlightCrates(BearycudaTr
  ialsOverlay.java:277)
      ...
```

Root caused it to be coming from trialBoatsById and trialCratesById were being cleaned up by calling map.remove() while iterating over map.values(), which is illegal on a HashMap and throws a ConcurrentModificationException.

So when we go to render the overlays it fails because we're still holding a null reference.

  **Fix**

Replaced the manual removal in the loops with entrySet().removeIf() which is how the toadFlagsbyId and trialBoostsByID are already handled in that method. This makes sure the maps are cleaned on world view unload so we never try to render stale objects.

  **Testing**

  Ran locally and verified the overlays were now loading.

 ![img](https://i.postimg.cc/X71pj2k6/Screenshot-2026-03-17-at-7-12-54-PM.png)